### PR TITLE
Update to openid_connect 1.0

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,5 @@
+---
+name: omniauth-shopify
+up:
+  - ruby: 2.3.1
+  - bundler

--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'omniauth', '~> 1.1'
-  spec.add_dependency 'openid_connect', '~> 0.9.2'
+  spec.add_dependency 'openid_connect', '~> 1.0'
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
I need openid_connect to be at least version 1.0 for this to coexist with IdentityClient.

Bumping the dependency here allows me to update this gem in Partners.