### PR TITLE
Bumped openid-connect gem to most recent version

### DIFF
--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'omniauth', '~> 1.1'
-  spec.add_dependency 'openid_connect', '~> 0.9.2'
+  spec.add_dependency 'openid_connect', '~> 1.1.3'
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "minitest"


### PR DESCRIPTION
Partners app is looking to upgrade to rails 5.1.3 and to do so we need to update the openid_connect version.