### PR TITLE
Handle http scheme configured in provider

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -87,6 +87,11 @@ module OmniAuth
       end
 
       def request_phase
+        if client_options.scheme == "http"
+          WebFinger.url_builder = URI::HTTP
+          SWD.url_builder = URI::HTTP
+        end
+
         options.issuer = issuer if options.issuer.blank?
         discover! if options.discovery
         redirect authorize_uri

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -70,6 +70,15 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     strategy.request_phase
   end
 
+  def test_request_phase_with_http
+    expected_redirect = /^http:\/\/.*$/
+    strategy.options.client_options.scheme = 'http'
+    strategy.options.issuer = 'example.com'
+    strategy.options.client_options.host = 'example.com'
+    strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+    strategy.request_phase
+  end
+
   def test_uid
     assert_equal user_info.sub, strategy.uid
   end


### PR DESCRIPTION
This is helpful for dev environments / if the auth provider is not
configured with SSL.