### PR TITLE
Add ui_locales to authorize uri

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -133,6 +133,7 @@ module OmniAuth
             id_token_hint: options.id_token_hint,
             login_hint: options.login_hint,
             ux: options.ux,
+            ui_locales: options.ui_locales,
         }
         client.authorization_uri(opts.reject{|k,v| v.nil?})
       end

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -69,6 +69,15 @@ class OmniAuth::Strategies::OpenIDConnectTest < StrategyTestCase
     strategy.expects(:redirect).with(regexp_matches(expected_redirect))
     strategy.request_phase
   end
+  
+  def test_request_phase_with_ui_locales
+    expected_redirect = /^https:\/\/example\.com\/authorize\?client_id=1234&nonce=[\w\d]{32}&response_type=code&scope=openid&state=[\w\d]{32}&ui_locales=fr\+en$/
+    strategy.options.ui_locales = 'fr en'
+    strategy.options.issuer = 'example.com'
+    strategy.options.client_options.host = 'example.com'
+    strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+    strategy.request_phase
+  end
 
   def test_uid
     assert_equal user_info.sub, strategy.uid


### PR DESCRIPTION
Add `ui_locales` to authorize url.  

`ui_locales` will be used to translate login/signup page and for the new user, it'll be saved as their locale in account table.