### PR TITLE
Fix omniauth vulnerability

### DIFF
--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'omniauth', '~> 1.1'
+  spec.add_dependency 'omniauth-rails_csrf_protection', '~> 0.1.2'
   spec.add_dependency 'openid_connect', '~> 1.1.6'
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
[From Github]

The request phase of the OmniAuth Ruby gem is vulnerable to Cross-Site Request Forgery when used as part of the Ruby on Rails framework, allowing accounts to be connected without user intent, user interaction, or feedback to the user. This permits a secondary account to be able to sign into the web application as the primary account.

In order to mitigate this vulnerability, I have replaced the `omniauth` gem with `omniauth-rails_csrf_protection` gem. More info is available in this [PR](https://github.com/omniauth/omniauth/pull/809#issuecomment-502079405).