### PR TITLE
Update omniauth-rails_csrf_protection to 1.0.0

### DIFF
--- a/omniauth-openid-connect.gemspec
+++ b/omniauth-openid-connect.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'omniauth-rails_csrf_protection', '~> 0.1.2'
+  spec.add_dependency 'omniauth-rails_csrf_protection', '~> 1.0.0'
   spec.add_dependency 'openid_connect', '~> 1.1.6'
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_development_dependency "bundler", "~> 1.5"


### PR DESCRIPTION
### Background 

Related to https://github.com/Shopify/partners/pull/37612
 
Update `omniauth-rails_csrf_protection` to `1.0.0` in order to update `omniauth` to version `2.0` in Partners app. 
See [rails upgrade guide](https://github.com/omniauth/omniauth/wiki/Upgrading-to-2.0#rails) for more details.